### PR TITLE
Decouple with ssh-agent role

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ install:
 - ssh-keygen -f /home/travis/.ssh/id_rsa -N ''
 
 script:
-- ansible-playbook -vv test.yml --sudo
+- ansible-playbook -vv test.yml --become-method=sudo

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
 - bash ansible-setup ansible_ref_require $ANSIBLE_REF /usr/bin
 - bash ansible-setup lxc_require
 - bash ansible-setup lxc_python2_require
-- ansible-galaxy install -p . -r test-requirements.yml
+- ssh-keygen -f /home/travis/.ssh/id_rsa -N ''
 
 script:
 - ansible-playbook -v test.yml --sudo

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ install:
 - ssh-keygen -f /home/travis/.ssh/id_rsa -N ''
 
 script:
-- ansible-playbook -v test.yml --sudo
+- ansible-playbook -vv test.yml --sudo

--- a/README.rst
+++ b/README.rst
@@ -25,9 +25,7 @@ And a playbook like that::
     - hosts: localhost
       become: true
       become_user: root
-      become_method: sudo
       roles:
-      - novafloss.ssh-agent
       - novafloss.boot-lxc
 
     - hosts: redis
@@ -41,8 +39,3 @@ And a playbook like that::
 First, novafloss.boot-lxc will start the containers and create them if they
 don't exist, then plays will be executed normally on rabbitmq and redis
 container hosts.
-
-Note that it uses `novafloss.ssh-agent role
-<https://github.com/novafloss/ansible-ssh-agent>`_ to ensure that an SSH agent
-is working on the host. While that may not be necessary on your machine, it's
-required to execute on fresh containers ie. in CI environments.

--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,11 @@
 This role instanciates any inventory host that ends with ``.lxc`` and sets it
 up for ansible: install python, add your ssh key for root.
 
-Note that you need ``lxc``, ``dsnmasq``, and ``sudo`` to be properly
-configured. And ``lxc-python2`` (which require ``lxc-dev``) installed in your
-ansible environement. That means that you can create a container with internet
-access and that you can resolve it by ``name.lxc``. One way to set this up is
-to use `novafloss/ansible-setup
-<https://github.com/novafloss/ansible-setup>`_
+Note that you need ``lxc``, ``dsnmasq``, and ``sudo`` to be properly configured.
+And ``lxc-python2`` (which require ``lxc-dev``) installed in your ansible
+environment. That means that you can create a container with internet access and
+that you can resolve it by ``name.lxc``. One way to set this up is to use
+`novafloss/ansible-setup <https://github.com/novafloss/ansible-setup>`_
 
 Consider this example inventory::
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,5 @@
 ---
 ssh_home: '{{ lookup("env", "HOME") }}/.ssh'
-ssh_private_key: '{{ ssh_home }}/id_rsa'
-ssh_public_key: '{{ ssh_private_key }}.pub'
-owner: '{{ lookup("env", "USER") }}'
+ssh_public_key: '{{ ssh_home }}/id_rsa.pub'
 lxc_path: /var/lib/lxc
 lxc_drop_containers: false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,5 +19,3 @@ galaxy_info:
   categories:
   - networking
   - system
-
-dependencies: ['novafloss.ssh-agent']

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+- name: Setup SSH for LXC
+  blockinfile:
+    marker: "# {mark} ANSIBLE BOOT LXC MANAGED BLOCK"
+    dest: '{{ ssh_home }}/config'
+    block: |
+      Host *.lxc
+          # No need for security for disposable test containers
+          UserKnownHostsFile /dev/null
+          StrictHostKeyChecking no
+          User root
 
 - name: Start container
   lxc_container:

--- a/test-requirements.yml
+++ b/test-requirements.yml
@@ -1,3 +1,0 @@
----
-- src: git+http://github.com/novafloss/ansible-ssh-agent.git
-  name: novafloss.ssh-agent

--- a/test.yml
+++ b/test.yml
@@ -11,8 +11,6 @@
       lxc_container_config:
       - "lxc.mount.entry={{ playbook_dir }} srv none defaults,bind,create=dir,uid=0 0 0"
   roles:
-  - role: novafloss.ssh-agent
-    ssh_insecure: ['*.lxc']
   - .
 
 - hosts: testboot

--- a/test.yml
+++ b/test.yml
@@ -3,7 +3,6 @@
 - hosts: localhost
   become: true
   become_user: root
-  become_method: sudo
   pre_tasks:
   - add_host:
       name: testboot.lxc


### PR DESCRIPTION
C'est gênant d'avoir obligatoirement un code qui lance un agent et qui crée une clef privée à la volée. Vu qu'on a juste besoin de définir l'utilisateur et d'accepter les clefs publique du conteneur, une simple task suffit.