### PR TITLE
create .ssh/config

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
   blockinfile:
     marker: "# {mark} ANSIBLE BOOT LXC MANAGED BLOCK"
     dest: '{{ ssh_home }}/config'
+    create: true
     block: |
       Host *.lxc
           # No need for security for disposable test containers


### PR DESCRIPTION
The file `$HOME/.ssh/config` may not exist.

On a fresh Debian/testing, the task crashes because of this reason.
This PR allows Ansible to create the file.