### PR TITLE
'remote_user' must be root for some tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,7 @@
 - name: Install python in container
   raw: if ! hash python2; then apt-get update -y && apt-get install -y python; fi
   become: no
+  remote_user: root
   delegate_to: '{{ item }}'
   when: item.split('.')[-1] == 'lxc'
   with_items: '{{ groups["all"] }}'
@@ -55,6 +56,7 @@
     name: sudo
     update_cache: yes
   become: no
+  remote_user: root
   delegate_to: '{{ item }}'
   when: item.split('.')[-1] == 'lxc'
   with_items: '{{ groups["all"] }}'


### PR DESCRIPTION
Tasks [`Install python in container`](https://github.com/peopledoc/ansible-boot-lxc/blob/20e5b8ad2742c9ccce53172e600c1b27cb85d4bb/tasks/main.yml#L43) and `Install sudo in container` expect that remote user is `root` (SSH public key of unix user executing `ansible-playbook` command is added to `root` user in LXC containers by [`Add your ssh key to the container` task](https://github.com/peopledoc/ansible-boot-lxc/blob/20e5b8ad2742c9ccce53172e600c1b27cb85d4bb/tasks/main.yml#L27)).

Fixes this error:
```
TASK [novafloss.boot-lxc : Install python in container] ***
ailed: [localhost] (item=host.lxc) => {
    "item": "host.lxc",
    "unreachable": true
}
MSG:
Failed to connect to the host via ssh: Warning:
pilou@host.lxc: Permission denied (publickey,password).
```